### PR TITLE
Trajectory executor parameters

### DIFF
--- a/include/libada/Ada.hpp
+++ b/include/libada/Ada.hpp
@@ -312,7 +312,7 @@ private:
   // Names of the trajectory executors
   const std::string mArmTrajectoryExecutorName;
   const std::string mHandTrajectoryExecutorName = "j2n6s200_hand_controller";
-  
+
   double mCollisionResolution;
 
   /// Random generator

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -1,10 +1,10 @@
 #include "libada/Ada.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <mutex>
 #include <stdexcept>
 #include <string>
-#include <algorithm>
 
 #include <aikido/common/RNG.hpp>
 #include <aikido/constraint/CyclicSampleable.hpp>
@@ -83,10 +83,9 @@ const dart::common::Uri namedConfigurationsUri{
 // arm trajectory controllers that are meant to be used by ada.
 // needs to be consistent with the configurations in ada_launch
 const std::vector<std::string> availableArmTrajectoryExecutorNames{
-  "trajectory_controller",
-  "rewd_trajectory_controller",
-  "move_until_touch_topic_controller"
-};
+    "trajectory_controller",
+    "rewd_trajectory_controller",
+    "move_until_touch_topic_controller"};
 
 namespace {
 BodyNodePtr getBodyNodeOrThrow(
@@ -127,7 +126,12 @@ Ada::Ada(
 {
   simulation = true; // temporarily set simulation to true
 
-  if (std::find(availableArmTrajectoryExecutorNames.begin(), availableArmTrajectoryExecutorNames.end(), mArmTrajectoryExecutorName) == availableArmTrajectoryExecutorNames.end()) {
+  if (std::find(
+          availableArmTrajectoryExecutorNames.begin(),
+          availableArmTrajectoryExecutorNames.end(),
+          mArmTrajectoryExecutorName)
+      == availableArmTrajectoryExecutorNames.end())
+  {
     throw std::runtime_error("Arm Trajectory Controller is not valid!");
   }
 


### PR DESCRIPTION
Different demos require different controllers in libada. This PR makes the controllers configurable via constructor and fixes a related bug so that a unsuccessful switchControllers call always throws an exception.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`
