### PR TITLE
Match the order of parameter names defined in header

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -57,9 +57,9 @@ Eigen::MatrixXd createBwMatrixForTSR(
     double xTolerance,
     double yTolerance,
     double zTolerance,
-    double yawTolerance,
+    double rollTolerance,
     double pitchTolerance,
-    double rollTolerance)
+    double yawTolerance)
 {
   Eigen::MatrixXd bw = Eigen::Matrix<double, 6, 2>::Zero();
   bw(0, 0) = -xTolerance;


### PR DESCRIPTION
This PR fixes the mismatch of param names in `util::createBwMatrixTSR`. 
This ordering is the correct one defined by aikido's [TSR](https://github.com/personalrobotics/aikido/blob/master/include/aikido/constraint/dart/TSR.hpp).

This has been tested in the current WIP ada_demos by visualizing the TSRs.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Add unit test(s) for this change
