### PR TITLE
Make switch_controller public, minor updates for 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ endif()
 include(ExternalProject)
 
 find_package(DART 6.6.2 REQUIRED
-  OPTIONAL_COMPONENTS utils
+  COMPONENTS utils utils-urdf optimizer-nlopt
+
 )
 
 find_package(aikido 0.3.0 REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ install(FILES "package.xml"
 #
 
 include(ClangFormat)
-clang_format_setup(VERSION 3.8)
+clang_format_setup(VERSION 3.9)
 
 if(CLANG_FORMAT_EXECUTABLE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ include(ExternalProject)
 
 find_package(DART 6.6.2 REQUIRED
   COMPONENTS utils utils-urdf optimizer-nlopt
-
 )
 
 find_package(aikido 0.3.0 REQUIRED
@@ -170,7 +169,7 @@ install(FILES "package.xml"
 #
 
 include(ClangFormat)
-clang_format_setup(VERSION 3.9)
+clang_format_setup(VERSION 6.0)
 
 if(CLANG_FORMAT_EXECUTABLE)
 

--- a/include/libada/Ada.hpp
+++ b/include/libada/Ada.hpp
@@ -384,7 +384,7 @@ private:
   const bool mSimulation;
 
   // Names of the trajectory executors
-  std::string mArmTrajectoryExecutorName; // GL:allow this to be changed
+  std::string mArmTrajectoryExecutorName;
   const std::string mHandTrajectoryExecutorName = "j2n6s200_hand_controller";
 
   // Collision resolution.

--- a/include/libada/Ada.hpp
+++ b/include/libada/Ada.hpp
@@ -334,6 +334,13 @@ public:
   /// Closes Ada's hand
   void closeHand();
 
+  /// Switches between controllers.
+  /// \param[in] startControllers Controllers to start.
+  /// \param[in] stopControllesr Controllers to stop.
+  bool switchControllers(
+      const std::vector<std::string>& startControllers,
+      const std::vector<std::string>& stopControllers);
+
 private:
   // Named Configurations are read from a YAML file
   using ConfigurationMap = std::unordered_map<std::string, Eigen::VectorXd>;
@@ -363,13 +370,6 @@ private:
   std::shared_ptr<aikido::control::TrajectoryExecutor>
   createTrajectoryExecutor();
 
-  /// Switches between controllers.
-  /// \param[in] startControllers Controllers to start.
-  /// \param[in] stopControllesr Controllers to stop.
-  bool switchControllers(
-      const std::vector<std::string>& startControllers,
-      const std::vector<std::string>& stopControllers);
-
   /// Plans the end effector to a TSR.
   /// Throws a runtime_error if no trajectory could be found.
   /// \return trajectory if the planning is successful.
@@ -384,7 +384,7 @@ private:
   const bool mSimulation;
 
   // Names of the trajectory executors
-  const std::string mArmTrajectoryExecutorName;
+  std::string mArmTrajectoryExecutorName; // GL:allow this to be changed
   const std::string mHandTrajectoryExecutorName = "j2n6s200_hand_controller";
 
   // Collision resolution.

--- a/include/libada/AdaHand.hpp
+++ b/include/libada/AdaHand.hpp
@@ -127,12 +127,7 @@ private:
   ///
   /// Maps an end-effector transform name (string) to a transform.
   using EndEffectorTransformMap = std::
-      unordered_map<std::string,
-                    Eigen::Isometry3d,
-                    std::hash<std::string>,
-                    std::equal_to<std::string>,
-                    Eigen::aligned_allocator<std::pair<const std::string,
-                                                       Eigen::Isometry3d>>>;
+      unordered_map<std::string, Eigen::Isometry3d, std::hash<std::string>, std::equal_to<std::string>, Eigen::aligned_allocator<std::pair<const std::string, Eigen::Isometry3d>>>;
 
   /// Create controllers in real or simulation.
   ///

--- a/include/libada/AdaHandKinematicSimulationPositionCommandExecutor.hpp
+++ b/include/libada/AdaHandKinematicSimulationPositionCommandExecutor.hpp
@@ -81,9 +81,9 @@ private:
       = std::array<std::size_t, kNumPositionExecutors>{{1, 1}};
 
   /// Executor for proximal and distal joints
-  std::array<AdaFingerKinematicSimulationPositionCommandExecutorPtr,
-             kNumPositionExecutors>
-      mPositionCommandExecutors;
+  std::
+      array<AdaFingerKinematicSimulationPositionCommandExecutorPtr, kNumPositionExecutors>
+          mPositionCommandExecutors;
 
   /// Duration to wait for futures from executors
   constexpr static auto kWaitPeriod = std::chrono::milliseconds(0);

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -782,9 +782,7 @@ bool Ada::moveArmOnTrajectory(
     std::vector<double> smoothVelocityLimits)
 {
   if (!trajectory)
-  {
-    throw std::runtime_error("Trajectory execution failed: Empty trajectory.");
-  }
+    return false;
 
   std::vector<aikido::constraint::ConstTestablePtr> constraints;
 

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -623,7 +623,6 @@ Ada::createTrajectoryExecutor()
   {
     std::string serverName
         = mArmTrajectoryExecutorName + "/follow_joint_trajectory";
-    std::cout << "Create " << serverName << std::endl;
     return std::make_shared<RosTrajectoryExecutor>(
         *mNode,
         serverName,
@@ -651,9 +650,9 @@ bool Ada::switchControllers(
 
   if (mControllerServiceClient->call(srv) && srv.response.ok)
   {
-    std::cout << "Switch controller succeeded " << std::endl;
     mArmTrajectoryExecutorName = startControllers[0];
     mTrajectoryExecutor = createTrajectoryExecutor();
+    ROS_INFO_STREAM("Controllers switched");
     return true;
   }
   else
@@ -849,7 +848,6 @@ bool Ada::moveArmOnTrajectory(
   }
 
   auto future = executeTrajectory(std::move(timedTrajectory));
-  std::cout << "Got a future " << std::endl;
   try
   {
     future.get();

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -781,7 +781,9 @@ bool Ada::moveArmOnTrajectory(
     std::vector<double> smoothVelocityLimits)
 {
   if (!trajectory)
+  {
     return false;
+  }
 
   std::vector<aikido::constraint::ConstTestablePtr> constraints;
 

--- a/src/AdaHandKinematicSimulationPositionCommandExecutor.cpp
+++ b/src/AdaHandKinematicSimulationPositionCommandExecutor.cpp
@@ -8,14 +8,12 @@ constexpr std::chrono::milliseconds
     AdaHandKinematicSimulationPositionCommandExecutor::kWaitPeriod;
 constexpr int
     AdaHandKinematicSimulationPositionCommandExecutor::kNumPositionExecutors;
-constexpr std::array<std::size_t,
-                     AdaHandKinematicSimulationPositionCommandExecutor::
-                         kNumPositionExecutors>
-    AdaHandKinematicSimulationPositionCommandExecutor::kPrimalDofs;
-constexpr std::array<std::size_t,
-                     AdaHandKinematicSimulationPositionCommandExecutor::
-                         kNumPositionExecutors>
-    AdaHandKinematicSimulationPositionCommandExecutor::kDistalDofs;
+constexpr std::
+    array<std::size_t, AdaHandKinematicSimulationPositionCommandExecutor::kNumPositionExecutors>
+        AdaHandKinematicSimulationPositionCommandExecutor::kPrimalDofs;
+constexpr std::
+    array<std::size_t, AdaHandKinematicSimulationPositionCommandExecutor::kNumPositionExecutors>
+        AdaHandKinematicSimulationPositionCommandExecutor::kDistalDofs;
 
 //==============================================================================
 AdaHandKinematicSimulationPositionCommandExecutor::

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,5 @@
 #include "libada/util.hpp"
-
+#include <stdlib.h>
 #include <aikido/common/Spline.hpp>
 #include <aikido/distance/DistanceMetric.hpp>
 #include <aikido/distance/defaults.hpp>
@@ -21,8 +21,9 @@ void waitForUser(const std::string& msg, const std::shared_ptr<Ada>& ada)
   std::cin >> input;
   if (input == 'n')
   {
-    ROS_INFO_STREAM("Terminate with user input " << input);
+    ROS_INFO_STREAM("Aborting with user input " << input);
     ada->stopTrajectoryExecutor();
+    exit(1);
   }
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,4 @@
 #include "libada/util.hpp"
-#include <stdlib.h>
 #include <aikido/common/Spline.hpp>
 #include <aikido/distance/DistanceMetric.hpp>
 #include <aikido/distance/defaults.hpp>
@@ -8,6 +7,7 @@
 #include <aikido/trajectory/Interpolated.hpp>
 #include <aikido/trajectory/util.hpp>
 #include <dart/common/StlHelpers.hpp>
+#include <stdlib.h>
 
 namespace ada {
 namespace util {


### PR DESCRIPTION
This PR reflects the latest ada demo. 
It makes `switch_controllers` public so that a demo script can switch controllers during the demo (to/from MoveUntilTouch to Trajectory controller)

It also update clang version to 3.9 as this seems o be the default version in 16.04.

This code has been tested with latest ada demo. 

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ ] Add unit test(s) for this change
