### PR TITLE
Enforce C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.0)
 project(libada)
 set(library_VERSION 0.2.0)
 
 option(LIBADA_TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_STANDARD 14)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 #================================================================================


### PR DESCRIPTION
Upgrade minimum requirements for cmake and enforce usage of c++14. 
`libada` uses `std::make_unique` introduced in c++14.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`

**Before merging a pull request**

- [ ] Add unit test(s) for this change
