### PR TITLE
Make sure acceleration limits match velocity limits

### DIFF
--- a/include/libada/detail/Ada-impl.hpp
+++ b/include/libada/detail/Ada-impl.hpp
@@ -17,6 +17,13 @@ aikido::trajectory::UniqueSplinePtr Ada::postProcessPath(
                                     ? getAccelerationLimits()
                                     : accelerationLimits;
 
+  if(sentAccelerationLimits.size() != 6) {
+    sentAccelerationLimits.resize(6);
+    auto defaultAccelerationLimits = getAccelerationLimits();
+    sentAccelerationLimits << defaultAccelerationLimits(0), defaultAccelerationLimits(1), defaultAccelerationLimits(2),
+                              defaultAccelerationLimits(3), defaultAccelerationLimits(4), defaultAccelerationLimits(5);
+  }
+
   return mRobot->postProcessPath<PostProcessor>(
       sentVelocityLimits,
       sentAccelerationLimits,

--- a/include/libada/detail/Ada-impl.hpp
+++ b/include/libada/detail/Ada-impl.hpp
@@ -23,16 +23,6 @@ aikido::trajectory::UniqueSplinePtr Ada::postProcessPath(
             ? mArm->getMetaSkeleton()->getAccelerationUpperLimits()
             : accelerationLimits;
 
-  if (sentAccelerationLimits.size() != 6)
-  {
-    sentAccelerationLimits.resize(6);
-    auto defaultAccelerationLimits = getAccelerationLimits();
-    sentAccelerationLimits << defaultAccelerationLimits(0),
-        defaultAccelerationLimits(1), defaultAccelerationLimits(2),
-        defaultAccelerationLimits(3), defaultAccelerationLimits(4),
-        defaultAccelerationLimits(5);
-  }
-
   return mRobot->postProcessPath<PostProcessor>(
       sentVelocityLimits,
       sentAccelerationLimits,

--- a/include/libada/detail/Ada-impl.hpp
+++ b/include/libada/detail/Ada-impl.hpp
@@ -10,18 +10,27 @@ aikido::trajectory::UniqueSplinePtr Ada::postProcessPath(
     const Eigen::VectorXd& velocityLimits,
     const Eigen::VectorXd& accelerationLimits)
 {
-  auto sentVelocityLimits = (velocityLimits.squaredNorm() == 0.0)
-                                ? getVelocityLimits()
-                                : velocityLimits;
-  auto sentAccelerationLimits = (accelerationLimits.squaredNorm() == 0.0)
-                                    ? getAccelerationLimits()
-                                    : accelerationLimits;
+  auto sentVelocityLimits
+      = (velocityLimits.squaredNorm() == 0.0
+         || (std::size_t)velocityLimits.size()
+                != mArm->getMetaSkeleton()->getNumDofs())
+            ? mArm->getMetaSkeleton()->getVelocityUpperLimits()
+            : velocityLimits;
+  auto sentAccelerationLimits
+      = (accelerationLimits.squaredNorm() == 0.0
+         || (std::size_t)accelerationLimits.size()
+                != mArm->getMetaSkeleton()->getNumDofs())
+            ? mArm->getMetaSkeleton()->getAccelerationUpperLimits()
+            : accelerationLimits;
 
-  if(sentAccelerationLimits.size() != 6) {
+  if (sentAccelerationLimits.size() != 6)
+  {
     sentAccelerationLimits.resize(6);
     auto defaultAccelerationLimits = getAccelerationLimits();
-    sentAccelerationLimits << defaultAccelerationLimits(0), defaultAccelerationLimits(1), defaultAccelerationLimits(2),
-                              defaultAccelerationLimits(3), defaultAccelerationLimits(4), defaultAccelerationLimits(5);
+    sentAccelerationLimits << defaultAccelerationLimits(0),
+        defaultAccelerationLimits(1), defaultAccelerationLimits(2),
+        defaultAccelerationLimits(3), defaultAccelerationLimits(4),
+        defaultAccelerationLimits(5);
   }
 
   return mRobot->postProcessPath<PostProcessor>(

--- a/include/libada/detail/Ada-impl.hpp
+++ b/include/libada/detail/Ada-impl.hpp
@@ -10,18 +10,17 @@ aikido::trajectory::UniqueSplinePtr Ada::postProcessPath(
     const Eigen::VectorXd& velocityLimits,
     const Eigen::VectorXd& accelerationLimits)
 {
+  bool velLimitsInvalid
+      = (velocityLimits.squaredNorm() == 0.0)
+        || velocityLimits.size() != getVelocityLimits().size();
   auto sentVelocityLimits
-      = (velocityLimits.squaredNorm() == 0.0
-         || (std::size_t)velocityLimits.size()
-                != mArm->getMetaSkeleton()->getNumDofs())
-            ? mArm->getMetaSkeleton()->getVelocityUpperLimits()
-            : velocityLimits;
+      = velLimitsInvalid ? getVelocityLimits() : velocityLimits;
+
+  bool accLimitsInvalid
+      = (accelerationLimits.squaredNorm() == 0.0)
+        || accelerationLimits.size() != getAccelerationLimits().size();
   auto sentAccelerationLimits
-      = (accelerationLimits.squaredNorm() == 0.0
-         || (std::size_t)accelerationLimits.size()
-                != mArm->getMetaSkeleton()->getNumDofs())
-            ? mArm->getMetaSkeleton()->getAccelerationUpperLimits()
-            : accelerationLimits;
+      = accLimitsInvalid ? getAccelerationLimits() : accelerationLimits;
 
   return mRobot->postProcessPath<PostProcessor>(
       sentVelocityLimits,

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -569,13 +569,13 @@ Eigen::VectorXd Ada::getCurrentConfiguration() const
 //==============================================================================
 Eigen::VectorXd Ada::getVelocityLimits() const
 {
-  return mRobot->getMetaSkeleton()->getVelocityUpperLimits();
+  return mArm->getMetaSkeleton()->getVelocityUpperLimits();
 }
 
 //==============================================================================
 Eigen::VectorXd Ada::getAccelerationLimits() const
 {
-  return mRobot->getMetaSkeleton()->getAccelerationUpperLimits();
+  return mArm->getMetaSkeleton()->getAccelerationUpperLimits();
 }
 
 //==============================================================================


### PR DESCRIPTION
Fixing a quick bug introduced from the last PR.

We only need the first 6 joints of the acceleration limits (to match the size of the velocity limits).

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Add unit test(s) for this change
