### PR TITLE
Fix DOCS workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,6 @@ jobs:
           # Docs
           - os: ubuntu-20.04
             catkin: ON
-            aikidopy: OFF
             build: DOCS
             config: ""
     runs-on: ${{ matrix.os }}
@@ -28,10 +27,9 @@ jobs:
       USE_CATKIN: ${{ matrix.catkin }}
       BUILD_NAME: ${{ matrix.build }}
       CATKIN_CONFIG_OPTIONS: ${{ matrix.config }}
-      BUILD_AIKIDOPY: ${{ matrix.aikidopy }}
       BUILD_TYPE: Release
       DISTRIBUTION: ${{ secrets.DISTRIBUTION }}
-      REPOSITORY: aikido
+      REPOSITORY: libada
       SUDO: sudo
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:


### PR DESCRIPTION
DOCS workflow fails since it still reference Aikido (my mistake).

This should rectify that. I'll comment when the manual DOCS workflow dispatch succeeds.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [ N/A ] Format code with `make format`

**Before merging a pull request**

- [ N/A ] Add unit test(s) for this change
