### PR TITLE
Do not require python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ endif()
 
 if(NOT pybind11_FOUND)
   message(WARNING "Could not load pybind11. Cannot build python bindings.")
-  return()
 endif()
 
 #================================================================================


### PR DESCRIPTION
As per @jdchang1 .

These are not actually required, yet we return if we can't build them. This makes building for Ubuntu 18.04 unnecessarily difficult.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [ N/A ] Format code with `make format`

**Before merging a pull request**
- [ N/A ] Add unit test(s) for this change
