### PR TITLE
Tested Gen3 with new velocity and trajectory controllers

### DIFF
--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -3,23 +3,6 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50  
 
-group_joint_velocity_controller:
-  type: velocity_controllers/JointGroupVelocityController
-  joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-  gains:
-      joint_1: {p: 3000.0, i: 0.0, d: 2.0, i_clamp_min: -100.0, i_clamp_max: 100.0}
-      joint_2: {p: 50000.0, i: 0.0, d: 0.0, i_clamp_min: -5.0, i_clamp_max: 5.0}
-      joint_3: {p: 50000.0, i: 0.0, d: 0.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
-      joint_4: {p: 750.0, i: 0.0, d: 0.2, i_clamp_min: -1.0, i_clamp_max: 1.0}
-      joint_5: {p: 5000.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
-      joint_6: {p: 100.0, i: 0.0, d: 0.0, i_clamp_min: -0.1, i_clamp_max: 0.1}
-
 # whole-arm base velocity controller
 velocity_controller:
   mode: VELOCITY

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -15,59 +15,72 @@
   <arg name="api_session_inactivity_timeout_ms" default="35000"/> <!--milliseconds-->
   <arg name="api_connection_inactivity_timeout_ms" default="20000"/> <!--milliseconds-->
 
-   <!-- the controller node itself -->
-   <node pkg="jaco_hardware"
-          name="ros_control_kinova_jaco"
+  <!-- Gen2 Hardware Node -->
+  <node name="jaco_hardware"
+          pkg="jaco_hardware"
           type="jaco_hardware"
           output="screen"
           if="$(eval arg('version') == 2)" />
   
-   <node name="kortex_hardware" pkg="kortex_hardware" type="kortex_hardware"
+  <!-- Gen3 Hardware Node -->
+  <node name="kortex_hardware" pkg="kortex_hardware" type="kortex_hardware"
           output="screen" if="$(eval arg('version') == 3)">
       <param name="ip_address" value="$(arg ip_address)"/>
       <param name="username" value="$(arg username)"/>
       <param name="password" value="$(arg password)"/>
       <param name="api_session_inactivity_timeout_ms" value="$(arg api_session_inactivity_timeout_ms)"/>
       <param name="api_connection_inactivity_timeout_ms" value="$(arg api_connection_inactivity_timeout_ms)"/>
-   </node>
+  </node>
 
-   <!-- load controllers -->
-   <rosparam file="$(find libada)/config/gen$(arg version)_$(arg dof)dof.yaml" command="load" />
+  <!-- load controller configuration -->
+  <rosparam file="$(find libada)/config/gen$(arg version)_$(arg dof)dof.yaml" command="load" />
 
-   <node name="controller_spawner_started" pkg="controller_manager" type="spawner" respawn="false"
+  <!-- start joint state controller (required) -->
+  <node name="controller_spawner_started" pkg="controller_manager" type="spawner" respawn="false"
       output="screen"
       args="joint_state_controller" />
-   <node name="base_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
+
+  <!-- Gen2 Controllers -->
+  <node name="base_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
       output="screen" if="$(eval arg('version') == 2)"
       args="
-         --stopped
-         position_controller
-         velocity_controller
-         effort_controller
-         trajectory_controller
-         hand_controller
-         " />
+        --stopped
+        position_controller
+        velocity_controller
+        effort_controller
+        trajectory_controller
+        hand_controller
+        " />
 
-   <node name="base_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
+  <!-- Gen3 Controllers -->
+  <node name="base_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
       output="screen" if="$(eval arg('version') == 3)"
       args="
-         --stopped
-         group_joint_velocity_controller
-         " />
+        --stopped
+        velocity_controller
+        trajectory_controller
+        " />
+
+  <!-- TODO: Initialize controllers directly via Aikido -->
+
+
+  <!-- Load Base URDF Files -->
+  <group unless="$(arg use_forque)">
+    <!-- load ada urdf -->
+    <param name="robot_description"
+          command="cat $(find ada_description)/robots_urdf/ada.urdf" if="$(eval arg('version') == 2)"/>
+    <param name="robot_description"
+          command="$(find xacro)/xacro --inorder $(find kortex_description)/robots/gen3_robotiq_2f_85.xacro sim:=false" if="$(eval arg('version') == 3)"/>
+  </group>
 
    <node pkg="robot_state_publisher" type="robot_state_publisher" name="rob_st_pub" />
 
    <node name="st_map2world" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
       args="0 0 0 0 0 0 1 map world 10"/>
 
-
-  <group unless="$(arg use_forque)">
-    <!-- load ada urdf -->
-    <param name="robot_description"
-          command="cat $(find ada_description)/robots_urdf/ada.urdf"/>
-  </group>
-
+  <!-- Initialize F/T Sensor -->
   <group if="$(arg use_forque)">
+  <group if="$(eval arg('version') == 2)">
     <!-- load ada urdf -->
     <param name="robot_description"
           command="cat $(find ada_description)/robots_urdf/ada_with_camera_forque.urdf"/>
@@ -81,6 +94,7 @@
          --stopped
          move_until_touch_topic_controller
          " />
+  </group>
   </group>
 
   <group if="$(arg perception)">


### PR DESCRIPTION
[Describe this pull request. Link to relevant GitHub issues, if any.]

The new Kortex/Gen3 Hardware interface (https://github.com/empriselab/kortex_hardware) works with the new velocity and trajectory controllers.

This PR modifies default.launch to reference the new Gen3 base URDFs and launch the new controllers.

New URDF files dependent on: https://github.com/personalrobotics/ada_description/pull/25

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [ N/A ] Format code with `make format`

**Before merging a pull request**

- [ N/A ] Add unit test(s) for this change
