### PR TITLE
Add pr_tsr as proper dep, and add joint_mode controller initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,11 @@ find_package(srdfdom REQUIRED)
 
 find_package(urdf REQUIRED)
 
+find_package(pr_tsr QUIET)
+if(NOT pr_tsr_FOUND)
+  message(WARNING "pr_tsr not found. Cannot build pr_tsr python bindings.")
+endif()
+
 
 #================================================================================
 # Compiler settings
@@ -146,14 +151,22 @@ target_link_libraries(libada
 #=============================================================================
 #Pybind
 if(pybind11_FOUND)
-  pybind11_add_module(adapy
-    MODULE
+
+  set(pybind_sources
     python/adapy/adapy.cpp
     python/adapy/ada_bindings.cpp
     python/adapy/aikido_bindings.cpp
     python/adapy/dart_bindings.cpp
-    python/adapy/pr_tsr_bindings.cpp
     python/adapy/ik_bindings.cpp
+  )
+
+  if(pr_tsr_FOUND)
+    list(APPEND pybind_sources python/adapy/pr_tsr_bindings.cpp)
+  endif()
+
+  pybind11_add_module(adapy
+    MODULE
+    ${pybind_sources}
   )
 
   target_include_directories(adapy

--- a/config/gen2_6dof.yaml
+++ b/config/gen2_6dof.yaml
@@ -7,10 +7,16 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
 
+# whole-arm joint mode controller
+joint_mode_controller:
+  mode: MODE
+  type: pr_ros_controllers/JointModeController
+  default: VELOCITY
+  joints: [joint_mode]
+
 # whole-arm base velocity controller
 velocity_controller:
   mode: VELOCITY
-  mode_handle: joint_mode
   type: pr_ros_controllers/JointGroupVelocityController
   joints: [j2n6s200_joint_1, j2n6s200_joint_2, j2n6s200_joint_3,
     j2n6s200_joint_4, j2n6s200_joint_5, j2n6s200_joint_6]
@@ -18,7 +24,6 @@ velocity_controller:
 # whole-arm base position controller
 position_controller:
   mode: POSITION
-  mode_handle: joint_mode
   type: pr_ros_controllers/JointGroupPositionController
   joints: [j2n6s200_joint_1, j2n6s200_joint_2, j2n6s200_joint_3,
     j2n6s200_joint_4, j2n6s200_joint_5, j2n6s200_joint_6]
@@ -26,7 +31,6 @@ position_controller:
 # whole-arm base effort controller
 effort_controller:
   mode: EFFORT
-  mode_handle: joint_mode
   type: pr_ros_controllers/JointGroupEffortController
   joints: [j2n6s200_joint_1, j2n6s200_joint_2, j2n6s200_joint_3,
     j2n6s200_joint_4, j2n6s200_joint_5, j2n6s200_joint_6]

--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -1,12 +1,18 @@
 # Publish all joint states -----------------------------------
 joint_state_controller:
   type: joint_state_controller/JointStateController
-  publish_rate: 50  
+  publish_rate: 50
+
+# whole-arm joint mode controller
+joint_mode_controller:
+  mode: MODE
+  type: pr_ros_controllers/JointModeController
+  default: VELOCITY
+  joints: [joint_mode]
 
 # whole-arm base velocity controller
 velocity_controller:
   mode: VELOCITY
-  mode_handle: joint_mode
   type: pr_ros_controllers/JointGroupVelocityController
   joints: [joint_1, joint_2, joint_3,
     joint_4, joint_5, joint_6]
@@ -14,7 +20,6 @@ velocity_controller:
 # whole-arm base position controller
 position_controller:
   mode: POSITION
-  mode_handle: joint_mode
   type: pr_ros_controllers/JointGroupPositionController
   joints: [joint_1, joint_2, joint_3,
     joint_4, joint_5, joint_6]
@@ -22,7 +27,6 @@ position_controller:
 # whole-arm base effort controller
 effort_controller:
   mode: EFFORT
-  mode_handle: joint_mode
   type: pr_ros_controllers/JointGroupEffortController
   joints: [joint_1, joint_2, joint_3,
     joint_4, joint_5, joint_6]

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -35,10 +35,13 @@
   <!-- load controller configuration -->
   <rosparam file="$(find libada)/config/gen$(arg version)_$(arg dof)dof.yaml" command="load" />
 
-  <!-- start joint state controller (required) -->
+  <!-- start joint state and mode controllers -->
   <node name="controller_spawner_started" pkg="controller_manager" type="spawner" respawn="false"
       output="screen"
-      args="joint_state_controller" />
+      args="
+        joint_state_controller
+        joint_mode_controller
+      " />
 
   <!-- Gen2 Controllers -->
   <node name="base_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"


### PR DESCRIPTION
pr_tsr is only required for Adapy. Make an optional call to find_package in CMakeLists, and only build the relevant bindings if it is present.

In addition, initialize the new Joint Mode Controller from https://github.com/personalrobotics/pr_ros_controllers/pull/27 for both Gen2 and Gen3 arms.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [ N/A ] Format code with `make format`

**Before merging a pull request**

- [ N/A ] Add unit test(s) for this change
