### PR TITLE
Read joint names for new Aikido TrajectoryExecutor interface

### DIFF
--- a/include/libada/AdaHand.hpp
+++ b/include/libada/AdaHand.hpp
@@ -142,7 +142,7 @@ private:
   ///
   /// \param[in] robot Robot to construct executor for
   std::shared_ptr<aikido::control::TrajectoryExecutor> createTrajectoryExecutor(
-      const dart::dynamics::SkeletonPtr& robot);
+      const dart::dynamics::MetaSkeletonPtr& robot);
 
   /// Create a controller for simulated hand movement.
   ///

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -12,6 +12,7 @@
 #include <aikido/constraint/Satisfied.hpp>
 #include <aikido/control/KinematicSimulationTrajectoryExecutor.hpp>
 #include <aikido/control/ros/RosTrajectoryExecutor.hpp>
+#include <aikido/control/util.hpp>
 #include <aikido/distance/defaults.hpp>
 #include <aikido/io/yaml.hpp>
 #include <aikido/planner/kunzretimer/KunzRetimer.hpp>
@@ -636,7 +637,8 @@ Ada::createTrajectoryExecutor()
         *mNode,
         serverName,
         rosTrajectoryInterpolationTimestep,
-        rosTrajectoryGoalTimeTolerance);
+        rosTrajectoryGoalTimeTolerance,
+        aikido::control::skeletonToJointNames(mArm->getMetaSkeleton()));
   }
 }
 

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -215,8 +215,6 @@ Ada::Ada(
 
   mSpace = std::make_shared<MetaSkeletonStateSpace>(mRobotSkeleton.get());
 
-  mTrajectoryExecutor = createTrajectoryExecutor();
-
   // Setting arm base and end names
   mArmBaseName = "j2n6s200_link_base";
   mArmEndName = "j2n6s200_link_6";
@@ -232,6 +230,8 @@ Ada::Ada(
   mArm->setVectorFieldPlannerParameters(vfParams);
 
   mArmSpace = mArm->getStateSpace();
+
+  mTrajectoryExecutor = createTrajectoryExecutor();
 
   // Set up the concrete robot from the meta skeleton
   mRobot = std::make_shared<ConcreteRobot>(
@@ -627,7 +627,7 @@ Ada::createTrajectoryExecutor()
   if (mSimulation)
   {
     return std::make_shared<KinematicSimulationTrajectoryExecutor>(
-        mRobotSkeleton);
+        mArm->getMetaSkeleton());
   }
   else
   {
@@ -638,7 +638,7 @@ Ada::createTrajectoryExecutor()
         serverName,
         rosTrajectoryInterpolationTimestep,
         rosTrajectoryGoalTimeTolerance,
-        aikido::control::skeletonToJointNames(mArm->getMetaSkeleton()));
+        mArm->getMetaSkeleton()->getDofs());
   }
 }
 

--- a/src/AdaHand.cpp
+++ b/src/AdaHand.cpp
@@ -5,6 +5,7 @@
 #include <aikido/constraint/Satisfied.hpp>
 #include <aikido/control/KinematicSimulationTrajectoryExecutor.hpp>
 #include <aikido/control/ros/RosTrajectoryExecutor.hpp>
+#include <aikido/control/util.hpp>
 #include <aikido/planner/SnapConfigurationToConfigurationPlanner.hpp>
 #include <aikido/planner/World.hpp>
 #include <aikido/planner/dart/ConfigurationToConfiguration.hpp>
@@ -424,7 +425,8 @@ AdaHand::createTrajectoryExecutor(const dart::dynamics::SkeletonPtr& robot)
         *mNode,
         serverName,
         rosTrajectoryInterpolationTimestep,
-        rosTrajectoryGoalTimeTolerance);
+        rosTrajectoryGoalTimeTolerance,
+        aikido::control::skeletonToJointNames(mHand));
   }
 }
 

--- a/src/AdaHand.cpp
+++ b/src/AdaHand.cpp
@@ -106,7 +106,6 @@ AdaHand::AdaHand(
     mNode = std::make_unique<::ros::NodeHandle>(*node);
   }
 
-  auto robotSkeleton = mHandBaseBodyNode->getSkeleton();
   std::vector<BodyNode*> bodyNodes;
   bodyNodes.reserve(mHandBaseBodyNode->getNumChildBodyNodes());
   for (size_t i = 0; i < mHandBaseBodyNode->getNumChildBodyNodes(); ++i)
@@ -117,10 +116,7 @@ AdaHand::AdaHand(
   mHand = Group::create("Hand", bodyNodes);
   mSpace = std::make_shared<MetaSkeletonStateSpace>(mHand.get());
 
-  mExecutor = createTrajectoryExecutor(robotSkeleton);
-
-  // TODO(Gilwoo): Use this to find the set point when grabbing object.
-  // mSimExecutor = createSimPositionCommandExecutor(robotSkeleton);
+  mExecutor = createTrajectoryExecutor(mHand);
 
   loadPreshapes(preshapesUri, retriever);
 
@@ -408,7 +404,7 @@ AdaHand::EndEffectorTransformMap AdaHand::parseYAMLToEndEffectorTransforms(
 
 //==============================================================================
 std::shared_ptr<aikido::control::TrajectoryExecutor>
-AdaHand::createTrajectoryExecutor(const dart::dynamics::SkeletonPtr& robot)
+AdaHand::createTrajectoryExecutor(const dart::dynamics::MetaSkeletonPtr& robot)
 {
   using aikido::control::KinematicSimulationTrajectoryExecutor;
   using aikido::control::ros::RosTrajectoryExecutor;
@@ -426,7 +422,7 @@ AdaHand::createTrajectoryExecutor(const dart::dynamics::SkeletonPtr& robot)
         serverName,
         rosTrajectoryInterpolationTimestep,
         rosTrajectoryGoalTimeTolerance,
-        aikido::control::skeletonToJointNames(mHand));
+        mHand->getDofs());
   }
 }
 


### PR DESCRIPTION
Makes libada compatible with https://github.com/personalrobotics/aikido/pull/602

Does not change interface or functionality.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [ N/A ] Add unit test(s) for this change
