### PR TITLE
Making libada hardware agnostic to gen2 & gen3

### DIFF
--- a/config/gen2_6dof.yaml
+++ b/config/gen2_6dof.yaml
@@ -1,7 +1,7 @@
 # Arm configuration parameters
 adaConf:
-  default_urdf: package://ada_description/robots_urdf/ada_with_camera.urdf
-  default_srdf: package://ada_description/robots_urdf/ada_with_camera.srdf
+  default_urdf: package://ada_description/robots_urdf/ada_with_camera_forque.urdf
+  default_srdf: package://ada_description/robots_urdf/ada_with_camera_forque.srdf
   default_accel_lim: 2.0
   default_vel_lim: 0.7
   end_effector: j2n6s200_end_effector

--- a/config/gen2_6dof.yaml
+++ b/config/gen2_6dof.yaml
@@ -58,22 +58,22 @@ trajectory_controller:
     stopped_velocity_tolerance: 1.0
     j2n6s200_joint_1:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_2:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_3:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_4:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_5:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_6:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
   gains: # Required because we're controlling a velocity interface
     j2n6s200_joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
@@ -100,22 +100,22 @@ move_until_touch_topic_controller:
   constraints:
     j2n6s200_joint_1:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_2:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_3:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_4:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_5:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_6:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
   gains: # Required because we're controlling a velocity interface
     j2n6s200_joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
@@ -123,6 +123,7 @@ move_until_touch_topic_controller:
     j2n6s200_joint_4: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_5: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_6: {p: 3,  d: 0, i: 0, i_clamp: 1}
+  max_ft_delay: 100
 
 # Optional controller that might be useful for testing.
 # Should do the same thing as trajectory_controller, but this is 
@@ -136,22 +137,22 @@ rewd_trajectory_controller:
     stopped_velocity_tolerance: 1.0
     j2n6s200_joint_1:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_2:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_3:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_4:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_5:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
     j2n6s200_joint_6:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 7
   gains: # Required because we're controlling a velocity interface
     j2n6s200_joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}

--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -156,3 +156,33 @@ rewd_trajectory_controller:
     joint_5: {p: 3,  d: 0, i: 0, i_clamp: 1}
     joint_6: {p: 3,  d: 0, i: 0, i_clamp: 1}
   control_type: velocity
+
+##############################################
+
+# gripper base velocity controller
+hand_velocity_controller:
+  mode: VELOCITY
+  type: pr_ros_controllers/JointGroupVelocityController
+  joints: [finger_joint]
+
+# gripper base position controller
+hand_position_controller:
+  mode: POSITION
+  type: pr_ros_controllers/JointGroupPositionController
+  joints: [finger_joint]
+
+# gripper base effort controller
+hand_effort_controller:
+  mode: EFFORT
+  type: pr_ros_controllers/JointGroupEffortController
+  joints: [finger_joint]
+
+hand_controller:
+  mode: TRAJECTORY
+  type: velocity_controllers/JointTrajectoryController
+  joints: [finger_joint]
+  constraints:
+    stopped_velocity_tolerance: 1.0
+  gains: # Required because we're controlling a velocity interface
+    finger_joint: {p: 1,  d: 0, i: 0, i_clamp: 1}
+

--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -4,8 +4,8 @@ adaConf:
   default_srdf: package://kortex_description/robots/gen3_6dof.srdf
   default_accel_lim: 2.0
   default_vel_lim: 0.7
-  end_effector: end_effector_link
-  arm: [base_link, robotiq_arg2f_base_link]
+  end_effector: robotiq_arg2f_base_link
+  arm: [base_link, bracelet_link]
   hand_base: end_effector_link
   arm_controller: trajectory_controller
   hand_controller: hand_controller

--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -4,8 +4,8 @@ adaConf:
   default_srdf: package://kortex_description/robots/gen3_6dof.srdf
   default_accel_lim: 2.0
   default_vel_lim: 0.7
-  end_effector: robotiq_arg2f_base_link
-  arm: [base_link, bracelet_link]
+  end_effector: end_effector_link
+  arm: [base_link, robotiq_arg2f_base_link]
   hand_base: end_effector_link
   arm_controller: trajectory_controller
   hand_controller: hand_controller

--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -54,22 +54,22 @@ trajectory_controller:
     stopped_velocity_tolerance: 1.0
     joint_1:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_2:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_3:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_4:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_5:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_6:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
   gains: # Required because we're controlling a velocity interface
     joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
@@ -88,37 +88,38 @@ move_until_touch_topic_controller:
   # FingerVision
   # forcetorque_wrench_name: /fingervision/fv_3_l/wrench
   # forcetorque_tare_name: /fingervision/fingerVisionTaring
-  sensor_force_limit: 50
-  sensor_torque_limit: 5
+  sensor_force_limit: 4
+  sensor_torque_limit: 1
   joints: [joint_1, joint_2, joint_3,
     joint_4, joint_5, joint_6]
   control_type: velocity
   constraints:
+    stopped_velocity_tolerance: 1.0
     joint_1:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 1
     joint_2:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 1
     joint_3:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 1
     joint_4:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 1
     joint_5:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 1
     joint_6:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 1
   gains: # Required because we're controlling a velocity interface
-    joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_3: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_4: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_5: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_6: {p: 3,  d: 0, i: 0, i_clamp: 1}
+    joint_1: {p: 1.2,  d: 0, i: 0, i_clamp: 1.0}
+    joint_2: {p: 1.2,  d: 0, i: 0, i_clamp: 1.0}
+    joint_3: {p: 1.2,  d: 0, i: 0, i_clamp: 1.0}
+    joint_4: {p: 1.2,  d: 0, i: 0, i_clamp: 1.0}
+    joint_5: {p: 1.2,  d: 0, i: 0, i_clamp: 1.0}
+    joint_6: {p: 1.2,  d: 0, i: 0, i_clamp: 1.0}
 
 # Optional controller that might be useful for testing.
 # Should do the same thing as trajectory_controller, but this is 
@@ -132,29 +133,29 @@ rewd_trajectory_controller:
     stopped_velocity_tolerance: 1.0
     joint_1:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_2:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_3:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_4:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_5:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
     joint_6:
       goal: 0.02
-      trajectory: 0.05
+      trajectory: 10.0
   gains: # Required because we're controlling a velocity interface
-    joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_3: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_4: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_5: {p: 3,  d: 0, i: 0, i_clamp: 1}
-    joint_6: {p: 3,  d: 0, i: 0, i_clamp: 1}
+    joint_1: {p: 0.2,  d: 0, i: 0, i_clamp: 1}
+    joint_2: {p: 0.2,  d: 0, i: 0, i_clamp: 1}
+    joint_3: {p: 0.2,  d: 0, i: 0, i_clamp: 1}
+    joint_4: {p: 0.2,  d: 0, i: 0, i_clamp: 1}
+    joint_5: {p: 0.2,  d: 0, i: 0, i_clamp: 1}
+    joint_6: {p: 0.2,  d: 0, i: 0, i_clamp: 1}
   control_type: velocity
 
 ##############################################

--- a/config/gen3_6dof.yaml
+++ b/config/gen3_6dof.yaml
@@ -88,8 +88,8 @@ move_until_touch_topic_controller:
   # FingerVision
   # forcetorque_wrench_name: /fingervision/fv_3_l/wrench
   # forcetorque_tare_name: /fingervision/fingerVisionTaring
-  sensor_force_limit: 4
-  sensor_torque_limit: 1
+  sensor_force_limit: 50
+  sensor_torque_limit: 5
   joints: [joint_1, joint_2, joint_3,
     joint_4, joint_5, joint_6]
   control_type: velocity

--- a/include/libada/Ada.hpp
+++ b/include/libada/Ada.hpp
@@ -98,9 +98,9 @@ public:
   Ada(bool simulation,
       const dart::common::Uri& adaUrdfUri = dart::common::Uri(""),
       const dart::common::Uri& adaSrdfUri = dart::common::Uri(""),
+      aikido::planner::WorldPtr env = aikido::planner::World::create(),
       const std::string confNamespace = DEFAULT_CONF_OBJ_NS,
       const std::chrono::milliseconds threadCycle = DEFAULT_THREAD_CYCLE,
-      aikido::planner::WorldPtr env = aikido::planner::World::create(),
       const ::ros::NodeHandle* node = nullptr,
       aikido::common::RNG::result_type rngSeed = std::random_device{}(),
       const dart::common::ResourceRetrieverPtr& retriever

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -62,6 +62,7 @@
         --stopped
         velocity_controller
         trajectory_controller
+        hand_controller
         " />
 
   <!-- TODO: Initialize controllers directly via Aikido -->

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -92,6 +92,8 @@
     <node name="st_joule2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
           args="0.09909 0.0181061 0.0178372 2.8905 3.13479 1.59224 j2n6s200_joule camera_link 10"/>
   </group>
+    <param name="robot_description"
+          command="$(find xacro)/xacro --inorder $(find kortex_description)/robots/gen3_robotiq_2f_85.xacro sim:=false" if="$(eval arg('version') == 3)"/>
     <node name="forque_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
           output="screen"
           args="

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -91,14 +91,13 @@
 
     <node name="st_joule2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
           args="0.09909 0.0181061 0.0178372 2.8905 3.13479 1.59224 j2n6s200_joule camera_link 10"/>
-
-    <node name="forque_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
-      output="screen"
-      args="
-         --stopped
-         move_until_touch_topic_controller
-         " />
   </group>
+    <node name="forque_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
+          output="screen"
+          args="
+             --stopped
+             move_until_touch_topic_controller
+             " />
   </group>
 
   <group if="$(arg perception)">

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -89,8 +89,8 @@
     <param name="robot_description"
           command="cat $(find ada_description)/robots_urdf/ada_with_camera_forque.urdf"/>
 
-    <node name="st_joule2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-          args="0.09909 0.0181061 0.0178372 2.8905 3.13479 1.59224 j2n6s200_joule camera_link 10"/>
+    <node name="st_robot2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
+            args="0.0792 0.0180 0.1316 -0.0374 0.8052 -0.0039 0.5918 j2n6s200_forque camera_link 10"/>
   </group>
     <param name="robot_description"
           command="$(find xacro)/xacro --inorder $(find kortex_description)/robots/gen3_robotiq_2f_85.xacro sim:=false" if="$(eval arg('version') == 3)"/>

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -84,14 +84,14 @@
 
   <!-- Initialize F/T Sensor -->
   <group if="$(arg use_forque)">
-  <group if="$(eval arg('version') == 2)">
-    <!-- load ada urdf -->
-    <param name="robot_description"
-          command="cat $(find ada_description)/robots_urdf/ada_with_camera_forque.urdf"/>
+    <group if="$(eval arg('version') == 2)">
+      <!-- load ada urdf -->
+      <param name="robot_description"
+            command="cat $(find ada_description)/robots_urdf/ada_with_camera_forque.urdf"/>
 
-    <node name="st_robot2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-            args="0.0768 0.0224 0.1386 0.0085 0.7949 0.0223 0.6063 j2n6s200_forque camera_link 10"/>
-  </group>
+      <node name="st_robot2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
+              args="0.0768 0.0224 0.1386 0.0085 0.7949 0.0223 0.6063 j2n6s200_forque camera_link 10"/>
+    </group>
     <param name="robot_description"
           command="$(find xacro)/xacro --inorder $(find kortex_description)/robots/gen3_robotiq_2f_85.xacro sim:=false" if="$(eval arg('version') == 3)"/>
     <node name="forque_controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -90,7 +90,7 @@
           command="cat $(find ada_description)/robots_urdf/ada_with_camera_forque.urdf"/>
 
     <node name="st_robot2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-            args="0.0792 0.0180 0.1316 -0.0374 0.8052 -0.0039 0.5918 j2n6s200_forque camera_link 10"/>
+            args="0.0768 0.0224 0.1386 0.0085 0.7949 0.0223 0.6063 j2n6s200_forque camera_link 10"/>
   </group>
     <param name="robot_description"
           command="$(find xacro)/xacro --inorder $(find kortex_description)/robots/gen3_robotiq_2f_85.xacro sim:=false" if="$(eval arg('version') == 3)"/>

--- a/launch/simulation.launch
+++ b/launch/simulation.launch
@@ -1,21 +1,30 @@
 <launch>
 
   <arg name="perception" default="false" doc="Boolean flag of whether to set up the perception on ADA" />
+  <arg name="version" default="2" doc="Kinova Arm Version (JACO = 2, Kortex = 3)" />
+  <arg name="dof" default="6" doc="Number of degrees of freedom in arm" />
+
 
   <!-- load controller configuration -->
+  <!-- load based on version -->
   <rosparam file="$(find libada)/config/gen$(arg version)_$(arg dof)dof.yaml" command="load" />
 
-  <!-- Camera Calibration -->
-  <node name="st_joule2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-          args="0.10909 0.0181061 0.0178372 2.8905 3.13479 1.59224 j2n6s200_joule camera_link 10"/>
+  
+  <group if="$(eval arg('version') == 2)">
+    <!-- Camera Calibration -->
+    <node name="st_joule2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
+            args="0.10909 0.0181061 0.0178372 2.8905 3.13479 1.59224 j2n6s200_joule camera_link 10"/>
+    <!-- From realsense node -->
+    <node name="st_camera2optical" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
+            args="0 0.015 0 0.504 -0.5 0.499 -0.497 camera_link camera_color_optical_frame 10"/>
+  </group>
 
   <!-- Define Map -->
   <node name="st_map2base" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-      args="0 0 0 0 0 0 1 map j2n6s200_link_base 10"/>
+      args="0 0 0 0 0 0 1 map j2n6s200_link_base 10" if="$(eval arg('version') == 2)"/>
 
-  <!-- From realsense node -->
-  <node name="st_camera2optical" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-          args="0 0.015 0 0.504 -0.5 0.499 -0.497 camera_link camera_color_optical_frame 10"/>
+  <node name="st_map2base" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
+      args="0 0 0 0 0 0 1 map base_link 10" if="$(eval arg('version') == 3)"/>
 
   <group if="$(arg perception)">
     <!-- Simulated pose estimators -->

--- a/launch/simulation.launch
+++ b/launch/simulation.launch
@@ -20,11 +20,17 @@
   </group>
 
   <!-- Define Map -->
-  <node name="st_map2base" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-      args="0 0 0 0 0 0 1 map j2n6s200_link_base 10" if="$(eval arg('version') == 2)"/>
+  <node name="st_map2world" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
+      args="0 0 0 0 0 0 1 map world 10"/>
 
-  <node name="st_map2base" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
-      args="0 0 0 0 0 0 1 map base_link 10" if="$(eval arg('version') == 3)"/>
+  <!-- Publish Robot TF Tree -->
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="rob_st_pub" />
+  <!-- load ada urdf -->
+  <param name="robot_description"
+        command="cat $(find ada_description)/robots_urdf/ada.urdf" if="$(eval arg('version') == 2)"/>
+  <param name="robot_description"
+        command="cat $(find kortex_description)/robots/gen3_6dof_vision.urdf" if="$(eval arg('version') == 3)"/>
+
 
   <group if="$(arg perception)">
     <!-- Simulated pose estimators -->

--- a/launch/simulation.launch
+++ b/launch/simulation.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="perception" default="false" doc="Boolean flag of whether to set up the perception on ADA" />
+  <arg name="perception" default="true" doc="Boolean flag of whether to set up the perception on ADA" />
   <arg name="version" default="2" doc="Kinova Arm Version (JACO = 2, Kortex = 3)" />
   <arg name="dof" default="6" doc="Number of degrees of freedom in arm" />
 
@@ -9,7 +9,7 @@
   <!-- load based on version -->
   <rosparam file="$(find libada)/config/gen$(arg version)_$(arg dof)dof.yaml" command="load" />
 
-  
+
   <group if="$(eval arg('version') == 2)">
     <!-- Camera Calibration -->
     <node name="st_joule2camera" pkg="tf" type="static_transform_publisher" respawn="false" output="screen"
@@ -47,4 +47,3 @@
   </group>
 
 </launch>
-

--- a/src/Ada.cpp
+++ b/src/Ada.cpp
@@ -80,9 +80,9 @@ Ada::Ada(
     bool simulation,
     const dart::common::Uri& adaUrdfUri,
     const dart::common::Uri& adaSrdfUri,
+    aikido::planner::WorldPtr env,
     const std::string confNamespace,
     const std::chrono::milliseconds threadCycle,
-    aikido::planner::WorldPtr env,
     const ::ros::NodeHandle* node,
     aikido::common::RNG::result_type rngSeed,
     const dart::common::ResourceRetrieverPtr& retriever)


### PR DESCRIPTION
- Changed order of params in the constructor so that env can be passed with default confNamespace & threadCycle
- Made launch file hardware agnostic 
- Updated launch/config files for gen3 6dof with
    - hand controllers
    - TF tree publishing
    - move until touch controller