### PR TITLE
Added python binding for PlanToTSR and PlanToOffset and test cases

### DIFF
--- a/python/adapy/ada_bindings.cpp
+++ b/python/adapy/ada_bindings.cpp
@@ -147,6 +147,13 @@ aikido::trajectory::TrajectoryPtr plan_to_configuration(
   return trajectory;
 }
 
+aikido::trajectory::TrajectoryPtr plan_to_offset(
+    ada::Ada* self, const std::string bodyNodeName, const Eigen::Vector3d& offset)
+{
+  auto trajectory = self->getArm()->planToOffset(bodyNodeName, offset);
+  return trajectory;
+}
+
 void execute_trajectory(
     ada::Ada* self, const aikido::trajectory::TrajectoryPtr& trajectory)
 {
@@ -276,6 +283,7 @@ void Ada(pybind11::module& m)
       .def("compute_smooth_joint_space_path", compute_smooth_joint_space_path)
       .def("compute_retime_path", compute_retime_path)
       .def("plan_to_configuration", plan_to_configuration)
+      .def("plan_to_offset", plan_to_offset)
       .def("execute_trajectory", execute_trajectory)
       .def("start_viewer", start_viewer);
 

--- a/python/adapy/ada_bindings.cpp
+++ b/python/adapy/ada_bindings.cpp
@@ -154,6 +154,14 @@ aikido::trajectory::TrajectoryPtr plan_to_offset(
   return trajectory;
 }
 
+aikido::trajectory::TrajectoryPtr plan_to_tsr(
+    ada::Ada* self, const std::string bodyNodeName, 
+    const aikido::constraint::dart::TSRPtr& tsr)
+{
+  auto trajectory = self->getArm()->planToTSR(bodyNodeName, tsr);
+  return trajectory;
+}
+
 void execute_trajectory(
     ada::Ada* self, const aikido::trajectory::TrajectoryPtr& trajectory)
 {
@@ -284,6 +292,7 @@ void Ada(pybind11::module& m)
       .def("compute_retime_path", compute_retime_path)
       .def("plan_to_configuration", plan_to_configuration)
       .def("plan_to_offset", plan_to_offset)
+      .def("plan_to_tsr", plan_to_tsr)
       .def("execute_trajectory", execute_trajectory)
       .def("start_viewer", start_viewer);
 

--- a/python/adapy/ada_bindings.cpp
+++ b/python/adapy/ada_bindings.cpp
@@ -148,14 +148,17 @@ aikido::trajectory::TrajectoryPtr plan_to_configuration(
 }
 
 aikido::trajectory::TrajectoryPtr plan_to_offset(
-    ada::Ada* self, const std::string bodyNodeName, const Eigen::Vector3d& offset)
+    ada::Ada* self,
+    const std::string bodyNodeName,
+    const Eigen::Vector3d& offset)
 {
   auto trajectory = self->getArm()->planToOffset(bodyNodeName, offset);
   return trajectory;
 }
 
 aikido::trajectory::TrajectoryPtr plan_to_tsr(
-    ada::Ada* self, const std::string bodyNodeName, 
+    ada::Ada* self,
+    const std::string bodyNodeName,
     const aikido::constraint::dart::TSRPtr& tsr)
 {
   auto trajectory = self->getArm()->planToTSR(bodyNodeName, tsr);

--- a/python/scripts/README.md
+++ b/python/scripts/README.md
@@ -1,0 +1,25 @@
+To run the python scripts for testing libada - 
+
+1. Launch the robot
+    - Simulation
+ 	```
+ 	roslaunch libada simulation.launch
+ 	```
+ 	
+    - Real robot (e.g. Jaco Gen2 6-DOF)
+ 	```
+ 	roslaunch libada default.launch version:=2 dof:=6
+ 	```
+
+1. Run rviz
+    ```
+    rviz
+    ```
+
+1. Run the python script
+ 	```
+ 	source ~/<your workspace>/devel/setup.bash
+ 	python3 simple_trajectories.py
+ 	```
+
+ 	Change the ```IS_SIM``` flag to ```False``` when operating the real robot.

--- a/python/scripts/simple_trajectories.py
+++ b/python/scripts/simple_trajectories.py
@@ -67,16 +67,19 @@ if not rospy.is_shutdown():
     pdb.set_trace()
 
     if traj_off:
+        # move to grasp position
         ada.execute_trajectory(traj_off)
 
-    print("")
-    print("CLOSING HAND")
-    print("")
-    PRESHAPE = [1.1, 1.1]
-    ada.get_hand().execute_preshape(PRESHAPE)
-
-    if traj_off_rev:
-        ada.execute_trajectory(traj_off_rev)
+        # close hand to grasp object
+        PRESHAPE = [1.1, 1.1]
+        ada.get_hand().execute_preshape(PRESHAPE)
+        print("")
+        print("CLOSING HAND")
+        print("")
+        
+        if traj_off_rev:
+            # return to offset position
+            ada.execute_trajectory(traj_off_rev)
 
     print("")
     print("CONTINUE TO EXECUTE REVERSE")
@@ -84,11 +87,11 @@ if not rospy.is_shutdown():
     pdb.set_trace()
 
     ada.execute_trajectory(traj_rev)
-
+    
+    ada.get_hand().open()
     print("")
     print("OPENING HAND")
     print("")
-    ada.get_hand().open()
 
     print("")
     print("DONE! CONTINUE TO EXIT")

--- a/python/scripts/simple_trajectories.py
+++ b/python/scripts/simple_trajectories.py
@@ -18,6 +18,8 @@ if not rospy.is_shutdown():
         if not ada.start_trajectory_controllers():
             print("Could not start trajectory controller.")
             sys.exit(1) 
+    rospy.sleep(1)  # wait for ada to initialize
+
     viewer = ada.start_viewer("dart_markers/simple_trajectories", "map")
     canURDFUri = "package://pr_assets/data/objects/can.urdf"
     sodaCanPose = [1.0, 0.0, 0.73, 0, 0, 0, 1]
@@ -53,11 +55,28 @@ if not rospy.is_shutdown():
 
     ada.execute_trajectory(traj)
 
+    offset = [0., 0.1, 0.]
+    offset_rev = [0., -0.1, 0.]
+    hand_node = rospy.get_param("adaConf/hand_base")
+    traj_off = ada.plan_to_offset(hand_node, offset)
+    traj_off_rev = ada.plan_to_offset(hand_node, offset_rev)
+
+    print("")
+    print("CONTINUE TO OFFSET")
+    print("")
+    pdb.set_trace()
+
+    if traj_off:
+        ada.execute_trajectory(traj_off)
+
     print("")
     print("CLOSING HAND")
     print("")
     PRESHAPE = [1.1, 1.1]
     ada.get_hand().execute_preshape(PRESHAPE)
+
+    if traj_off_rev:
+        ada.execute_trajectory(traj_off_rev)
 
     print("")
     print("CONTINUE TO EXECUTE REVERSE")

--- a/python/scripts/tsr_example.py
+++ b/python/scripts/tsr_example.py
@@ -29,6 +29,7 @@ if not rospy.is_shutdown():
 
     collision = ada.get_self_collision_constraint()
 
+    # get arm and hand instances
     arm_skeleton = ada.get_arm_skeleton()
     arm_state_space = ada.get_arm_state_space()
     hand = ada.get_hand()
@@ -38,7 +39,7 @@ if not rospy.is_shutdown():
     viewer.add_frame(hand_node)
 
     print("")
-    print("CREATE TSR")
+    print("CONTINUE TO CREATE TSR")
     print("")
     pdb.set_trace()
 
@@ -52,8 +53,8 @@ if not rospy.is_shutdown():
     print("Tw_e", grasp_tsr.get_Tw_e())
 
     # set T0_w to can origin
-    T0_w[0, 3] = 0.2
-    T0_w[1, 3] = 0.2
+    T0_w[0, 3] = sodaCanPose[0]
+    T0_w[1, 3] = sodaCanPose[1]
     grasp_tsr.set_T0_w(T0_w)
 
     # set default Bw
@@ -84,13 +85,15 @@ if not rospy.is_shutdown():
     print("PLAN TO TSR")
     print("")
     pdb.set_trace()
+ 
+    trials, maxTrials = 0, 10
+    while trials < maxTrials:
 
-    samples, maxSamples = 0, 10
-    while samples < maxSamples:
+        # plan_to_tsr may require more than one try to find a succesful path
         traj = ada.plan_to_tsr(rospy.get_param("adaConf/end_effector"), grasp_tsr)
         if traj:
             break
-        samples += 1
+        trials += 1
 
     print("")
     print("CONTINUE TO EXECUTE")

--- a/python/scripts/tsr_example.py
+++ b/python/scripts/tsr_example.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+import adapy
+import rospy
+import sys
+
+import pdb
+from moveit_ros_planning_interface._moveit_roscpp_initializer import roscpp_init
+import numpy as np
+
+rospy.init_node("adapy_tsr_example")
+roscpp_init('adapy_tsr_example', [])
+rate = rospy.Rate(10)
+IS_SIM = True
+
+if not rospy.is_shutdown():
+    ada = adapy.Ada(IS_SIM)
+    if not IS_SIM:
+        if not ada.start_trajectory_controllers():
+            print("Could not start trajectory controller.")
+            sys.exit(1) 
+    rospy.sleep(1)  # wait for ada to initialize
+
+    viewer = ada.start_viewer("dart_markers/tsr_example", "map")
+    canURDFUri = "package://pr_assets/data/objects/can.urdf"
+    sodaCanPose = [0.2, 0.2, 0., 0, 0, 0, 1]
+    world = ada.get_world()
+    can = world.add_body_from_urdf(canURDFUri, sodaCanPose)
+
+    collision = ada.get_self_collision_constraint()
+
+    arm_skeleton = ada.get_arm_skeleton()
+    arm_state_space = ada.get_arm_state_space()
+    hand = ada.get_hand()
+    hand_node = hand.get_end_effector_body_node()
+    positions = ada.get_arm_positions()
+
+    viewer.add_frame(hand_node)
+
+    print("")
+    print("CREATE TSR")
+    print("")
+    pdb.set_trace()
+
+    # get default TSR for grasping can
+    grasp_tsr = adapy.get_default_TSR()
+    T0_w = grasp_tsr.get_T0_w()
+    print("T0_w", T0_w)
+    
+    # reset Tw_e to origin
+    grasp_tsr.set_Tw_e(T0_w)
+    print("Tw_e", grasp_tsr.get_Tw_e())
+
+    # set T0_w to can origin
+    T0_w[0, 3] = 0.2
+    T0_w[1, 3] = 0.2
+    grasp_tsr.set_T0_w(T0_w)
+
+    # set default Bw
+    Bw = np.zeros([6, 2])
+    grasp_tsr.set_Bw(Bw)
+
+    # visualize T0_w
+    canTSR = viewer.add_tsr_marker(grasp_tsr)
+    print("T0_w", grasp_tsr.get_T0_w())
+
+    # set Tw_e to grasp the can from the top
+    Tw_e = [[-1.,  0.,  0.,  0.00],
+            [ 0.,  1.,  0.,  0.00],
+            [ 0.,  0., -1.,  0.15],
+            [ 0.,  0.,  0.,  1.00]]
+    grasp_tsr.set_Tw_e(Tw_e)
+
+    # set Bw
+    Bw[5, 0] = -np.pi
+    Bw[5, 1] = np.pi
+    grasp_tsr.set_Bw(Bw)
+    
+    # visualize Tw_e
+    graspTSR = viewer.add_tsr_marker(grasp_tsr)
+    print("Tw_e", grasp_tsr.get_Tw_e())
+
+    print("")
+    print("PLAN TO TSR")
+    print("")
+    pdb.set_trace()
+
+    samples, maxSamples = 0, 10
+    while samples < maxSamples:
+        traj = ada.plan_to_tsr(rospy.get_param("adaConf/end_effector"), grasp_tsr)
+        if traj:
+            break
+        samples += 1
+
+    print("")
+    print("CONTINUE TO EXECUTE")
+    print("")
+    pdb.set_trace()
+
+    ada.execute_trajectory(traj)
+
+    print("")
+    print("DONE! CONTINUE TO EXIT")
+    print("")
+    pdb.set_trace()
+    if not IS_SIM:
+        if not ada.stop_trajectory_controllers():
+            print("Could not stop trajectory controllers.")


### PR DESCRIPTION
Added python bindings for planToTSR function
plan_to_offset(bodyNodeName, TSR) can be tested using tsr_example.py script.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format code with `make format`

**Before merging a pull request**

- [x] Add unit test(s) for this change
